### PR TITLE
removing trailing comma in v1p1 schema

### DIFF
--- a/v1.1/MAML_schema_v1p1.json
+++ b/v1.1/MAML_schema_v1p1.json
@@ -127,7 +127,7 @@
       }
     },
     "extra": {
-      "type": "object",
+      "type": "object"
     },
     "MAML_version": {
       "type": "number",


### PR DESCRIPTION
Line 130 has a trailing coma which I don't think is allowed in JSON. 

I just removed it. 

-TSL